### PR TITLE
Accommodate `!` to start questions

### DIFF
--- a/R/quiz.R
+++ b/R/quiz.R
@@ -33,7 +33,7 @@ parse_quiz_df <- function(quiz_lines, remove_tags = FALSE) {
         # Find which lines are the wrong answer options
         grepl("^[[:lower:]]{1}\\)", quiz_lines) ~ "wrong_answer",
         # Find which lines are the correct answer options
-        grepl("^[[:upper:]]{1}\\)|\\!", quiz_lines) ~ "correct_answer",
+        grepl("^[[:upper:]]{1}\\)|^\\!", quiz_lines) ~ "correct_answer",
         # Find the tags
         grepl("^\\{", quiz_lines) ~ "tag",
         # Mark empty lines

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -33,7 +33,7 @@ parse_quiz_df <- function(quiz_lines, remove_tags = FALSE) {
         # Find which lines are the wrong answer options
         grepl("^[[:lower:]]{1}\\)", quiz_lines) ~ "wrong_answer",
         # Find which lines are the correct answer options
-        grepl("^[[:upper:]]{1}\\)", quiz_lines) ~ "correct_answer",
+        grepl("^[[:upper:]]{1}\\)|\\!", quiz_lines) ~ "correct_answer",
         # Find the tags
         grepl("^\\{", quiz_lines) ~ "tag",
         # Mark empty lines


### PR DESCRIPTION
### Purpose/implementation Section

https://github.com/datatrail-jhu/DataTrail_Quizzes/actions/runs/3605669950/jobs/6076290643

Leanpub quiz checks are failing because fill-in-the-blank questions that use regex (e.g., the second quiz [here](https://github.com/datatrail-jhu/DataTrail_Quizzes/blob/main/quizzes/01_forming_questions_01_data_science_process_quiz.md)) are not considered "correct answers" by the ottrpal check. the `parse_quiz_df` function looks only for a `uppercase)` pattern, not the `!` pattern, which should be fine according to markua docs.

#### What changes are being implemented in this Pull Request?

Accommodate correct fill in the blank questions that start with `!` . Basically, looks for `C)` OR `!` to start the answer.
