### PR TITLE
Accommodate multiple css

### DIFF
--- a/R/coursera.R
+++ b/R/coursera.R
@@ -304,6 +304,9 @@ render_without_toc <- function(output_dir = file.path("docs", "no_toc"),
     css_files_read <- sapply(org_css_file, readLines)
     
     # Make a "mega .css" and write
+    if (verbose) {
+      message("Combining .css files")
+    }
     css_lines_cat <- rbind(unlist(css_files_read))
     css_file <- file.path(output_dir, org_css_file[1])
     writeLines(css_lines_cat, css_file)
@@ -324,8 +327,7 @@ render_without_toc <- function(output_dir = file.path("docs", "no_toc"),
   bookdown::render_book(
     input = "index.Rmd",
     output_yaml = output_yaml_file,
-    output_dir = output_dir,
-    clean_envir = FALSE
+    output_dir = output_dir
   )
 
   # Read in TOC closing CSS lines

--- a/R/coursera.R
+++ b/R/coursera.R
@@ -295,15 +295,27 @@ render_without_toc <- function(output_dir = file.path("docs", "no_toc"),
   # Retrieve yaml file specs
   output_yaml_lines <- yaml::yaml.load_file(output_yaml_file)
 
-  # Copy over css file that's specified
+  # Copy over css file(s) that's specified
   org_css_file <- output_yaml_lines$`bookdown::gitbook`$css
-  css_file <- file.path(output_dir, org_css_file)
-
-  # Write it as "style.css"
-  fs::file_copy(org_css_file,
-    css_file,
-    overwrite = TRUE
-  )
+  
+  # Check if there are multiple .css 
+  if(length(org_css_file) > 1){
+    # Read all .css
+    css_files_read <- sapply(org_css_file, readLines)
+    
+    # Make a "mega .css" and write
+    css_lines_cat <- rbind(unlist(css_files_read))
+    css_file <- file.path(output_dir, org_css_file[1])
+    writeLines(css_lines_cat, css_file)
+  } else {
+    css_file <- file.path(output_dir, org_css_file)
+    
+    # Write it as "style.css"
+    fs::file_copy(org_css_file,
+                  css_file,
+                  overwrite = TRUE
+    )
+  }
 
   ###### Now do the rendering! ######
   message("Render bookdown without TOC")


### PR DESCRIPTION
### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

Attempting a solution for https://github.com/jhudsl/OTTR_Template/issues/536. to accommodate:

```
bookdown::gitbook:
  css: [assets/style.css, assets/AnVIL_style/anvil.css]
```
#### What was your approach?

If multiple css files are provided in `_output.yml`, this now loops through and makes a "mega css" to proceed. 

Would appreciate if others can test/gut check this!