### PR TITLE
Resolve dependency on self

### DIFF
--- a/R/coursera.R
+++ b/R/coursera.R
@@ -213,6 +213,7 @@ convert_coursera_quizzes <- function(input_quiz_dir = "quizzes",
 #' @rdname coursera
 #'
 #' @importFrom utils download.file
+#' @import bookdown_path
 #'
 render_without_toc <- function(output_dir = file.path("docs", "no_toc"),
                                output_yaml = "_output.yml",


### PR DESCRIPTION
Ran into the issue of calling `ottrpal::render_without_toc` which depends on `ottrpal::bookdown_path` and getting an inscrutable message in github actions. Basically, it's not finding the path.

Going to do a quick test and make sure this works. 