### PR TITLE
Remove line `get_gs_pptx(url)` from `include_slide()`

### DIFF
--- a/R/gs_png.R
+++ b/R/gs_png.R
@@ -97,7 +97,6 @@ gs_png_download <- function(url, output_dir = ".", overwrite = TRUE) {
 include_slide <- function(url,
                           output_dir = knitr::opts_chunk$get("fig.path"),
                           overwrite = TRUE, ...) {
-  get_gs_pptx(url)
   outfile <- gs_png_download(url, output_dir, overwrite = overwrite)
   knitr::include_graphics(outfile, ...)
 }


### PR DESCRIPTION
While working on the Quarto version of OTTR, I noticed that the `include_slide()` function was downloading a Google Slide deck as a PPTX file with `get_gs_pptx(url)`.

After investigation, I realized that this was unnecessary as the line below, `outfile <- gs_png_download(url, output_dir, overwrite = overwrite)` was sufficient to download the individual slide from Google Slides as a PNG file and the next line, 
`knitr::include_graphics(outfile, ...)` embeds the PNG file in the document.